### PR TITLE
Use the previous date picker default style for iOS 14 and beyond

### DIFF
--- a/CFAlertViewController/Cells/CFAlertActionDatePickerViewTableViewCell.xib
+++ b/CFAlertViewController/Cells/CFAlertActionDatePickerViewTableViewCell.xib
@@ -17,7 +17,7 @@
                 <rect key="frame" x="0.0" y="0.0" width="320" height="167"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <datePicker contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="date" translatesAutoresizingMaskIntoConstraints="NO" id="q0J-Ve-4gA">
+                    <datePicker contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="date" style="wheels" translatesAutoresizingMaskIntoConstraints="NO" id="q0J-Ve-4gA">
                         <rect key="frame" x="16" y="0.0" width="288" height="166"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="166" id="VBi-YN-gi9"/>


### PR DESCRIPTION
This should ensure the questionnaire date picker uses the old style wheels, even in iOS 14.